### PR TITLE
feat: support width = 0 for full terminal width

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ colors, set it to `reset`.
 
 ```toml
 # General settings
-width = 100
+width = 100 # Set to 0 for full terminal width
 gitignore = false
 alignment = "left" # "center" | "right"
 

--- a/src/util/general.rs
+++ b/src/util/general.rs
@@ -26,8 +26,10 @@ pub static GENERAL_CONFIG: LazyLock<GeneralConfig> = LazyLock::new(|| {
         .build()
         .unwrap();
 
+    let width = settings.get::<u16>("width").unwrap_or(100);
     GeneralConfig {
-        width: settings.get::<u16>("width").unwrap_or(100),
+        // width = 0 means "use full terminal width"
+        width: if width == 0 { u16::MAX } else { width },
         gitignore: settings.get::<bool>("gitignore").unwrap_or(false),
         centering: settings
             .get::<Centering>("alignment")


### PR DESCRIPTION
{ Happy New Year! }

When width is set to 0 in config, use the full terminal width instead of the default 100 columns. This is achieved by setting the internal width to u16::MAX, which then gets clamped to the actual terminal width by the existing min() comparisons.

Example config:

```toml
width = 0  # use full terminal width
```
