### PR TITLE
Fix spelling: seperator → separator

### DIFF
--- a/src/md.pest
+++ b/src/md.pest
@@ -89,8 +89,8 @@ sentence          = _{ (latex | footnote_ref_container | code | link | bold_ital
 t_sentence        = _{ (!"|" ~ (latex | footnote_ref_container | code | link | bold_italic | italic | bold | strikethrough | t_normal))+ }
 footnote_sentence = _{ ((":" | (NEWLINE ~ "  ")) ~ WHITESPACE_S* ~ (latex | code | link | bold_italic | italic | bold | strikethrough | normal+))+ }
 
-table_cell      = { !table_seperator ~ "|" ~ WHITESPACE_S* ~ t_sentence* ~ WHITESPACE_S* ~ ("|" ~ " "* ~ NEWLINE)? }
-table_seperator = { ("|"? ~ (WHITESPACE_S | ":")* ~ "-"+ ~ (WHITESPACE_S | ":")* ~ "|") }
+table_cell      = { !table_separator ~ "|" ~ WHITESPACE_S* ~ t_sentence* ~ WHITESPACE_S* ~ ("|" ~ " "* ~ NEWLINE)? }
+table_separator = { ("|"? ~ (WHITESPACE_S | ":")* ~ "-"+ ~ (WHITESPACE_S | ":")* ~ "|") }
 
 u_list = { indent ~ ("-" | "*") ~ WHITESPACE_S ~ sentence+ }
 o_list = { indent ~ o_list_counter ~ sentence+ }
@@ -123,7 +123,7 @@ code_block          = {
     NEWLINE? ~ " "* ~ (("```" ~ programming_language? ~ code_line+ ~ " "* ~ "```") | ("~~~" ~ programming_language? ~ code_line+ ~ " "* ~ "~~~") | indented_code_block)
 }
 table               = {
-    NEWLINE? ~ table_cell+ ~ NEWLINE? ~ table_seperator+ ~ (NEWLINE? ~ table_cell)*
+    NEWLINE? ~ table_cell+ ~ NEWLINE? ~ table_separator+ ~ (NEWLINE? ~ table_cell)*
 }
 
 quote          = { (NEWLINE? ~ WHITESPACE_S* ~ ">" ~ ((quote_marking | sentence | " ")+ | NEWLINE))+ }

--- a/src/nodes/textcomponent.rs
+++ b/src/nodes/textcomponent.rs
@@ -25,7 +25,7 @@ pub enum TextNode {
     Table(Vec<u16>, Vec<u16>),
     CodeBlock,
     Quote,
-    HorizontalSeperator,
+    HorizontalSeparator,
 }
 
 #[derive(Debug, Clone)]
@@ -307,7 +307,7 @@ impl TextComponent {
             TextNode::Table(_, _) => {
                 transform_table(self, width);
             }
-            TextNode::HorizontalSeperator => self.height = 1,
+            TextNode::HorizontalSeparator => self.height = 1,
             TextNode::Image => unreachable!("Image should not be transformed"),
             TextNode::Footnote => self.height = 0,
         }

--- a/src/nodes/word.rs
+++ b/src/nodes/word.rs
@@ -41,11 +41,11 @@ impl From<MdParseEnum> for WordType {
     fn from(value: MdParseEnum) -> Self {
         match value {
             MdParseEnum::PLanguage
-            | MdParseEnum::BlockSeperator
+            | MdParseEnum::BlockSeparator
             | MdParseEnum::TaskOpen
             | MdParseEnum::TaskClosed
             | MdParseEnum::Indent
-            | MdParseEnum::HorizontalSeperator => WordType::MetaInfo(MetaData::Other),
+            | MdParseEnum::HorizontalSeparator => WordType::MetaInfo(MetaData::Other),
             MdParseEnum::FootnoteRef => WordType::FootnoteInline,
             MdParseEnum::Code => WordType::Code,
             MdParseEnum::Bold => WordType::Bold,
@@ -80,7 +80,7 @@ impl From<MdParseEnum> for WordType {
             | MdParseEnum::TableCell
             | MdParseEnum::Task
             | MdParseEnum::UnorderedList
-            | MdParseEnum::TableSeperator => {
+            | MdParseEnum::TableSeparator => {
                 unreachable!("Edit this or pest file to fix for value: {:?}", value)
             }
             MdParseEnum::CodeBlockStr | MdParseEnum::CodeBlockStrSpaceIndented => {

--- a/src/pages/markdown_renderer.rs
+++ b/src/pages/markdown_renderer.rs
@@ -90,7 +90,7 @@ impl Widget for TextComponent {
             }
             TextNode::Quote => render_quote(area, buf, self, clips),
             TextNode::LineBreak => (),
-            TextNode::HorizontalSeperator => render_horizontal_seperator(area, buf),
+            TextNode::HorizontalSeparator => render_horizontal_separator(area, buf),
             TextNode::Image => todo!(),
             TextNode::Footnote => (),
         }
@@ -605,7 +605,7 @@ fn render_task(
     paragraph.render(area, buf);
 }
 
-fn render_horizontal_seperator(area: Rect, buf: &mut Buffer) {
+fn render_horizontal_separator(area: Rect, buf: &mut Buffer) {
     let paragraph = Paragraph::new(Line::from(vec![Span::raw(
         "\u{2014}".repeat(GENERAL_CONFIG.width.into()),
     )]));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -334,7 +334,7 @@ fn parse_component(parse_node: ParseNode) -> Component {
         MdParseEnum::Table => {
             let mut words = Vec::new();
             for cell in parse_node.children_owned() {
-                if cell.kind() == MdParseEnum::TableSeperator {
+                if cell.kind() == MdParseEnum::TableSeparator {
                     words.push(vec![Word::new(
                         cell.content().to_owned(),
                         WordType::MetaInfo(MetaData::ColumnsCount),
@@ -373,11 +373,11 @@ fn parse_component(parse_node: ParseNode) -> Component {
             ))
         }
 
-        MdParseEnum::BlockSeperator => {
+        MdParseEnum::BlockSeparator => {
             Component::TextComponent(TextComponent::new(TextNode::LineBreak, Vec::new()))
         }
-        MdParseEnum::HorizontalSeperator => Component::TextComponent(TextComponent::new(
-            TextNode::HorizontalSeperator,
+        MdParseEnum::HorizontalSeparator => Component::TextComponent(TextComponent::new(
+            TextNode::HorizontalSeparator,
             Vec::new(),
         )),
         MdParseEnum::Footnote => {
@@ -532,7 +532,7 @@ impl ParseNode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MdParseEnum {
     AltText,
-    BlockSeperator,
+    BlockSeparator,
     Bold,
     BoldItalic,
     BoldItalicStr,
@@ -547,7 +547,7 @@ pub enum MdParseEnum {
     FootnoteRef,
     Footnote,
     Heading,
-    HorizontalSeperator,
+    HorizontalSeparator,
     Image,
     Imortant,
     Indent,
@@ -567,7 +567,7 @@ pub enum MdParseEnum {
     StrikethroughStr,
     Table,
     TableCell,
-    TableSeperator,
+    TableSeparator,
     Task,
     TaskClosed,
     TaskOpen,
@@ -606,7 +606,7 @@ impl From<Rule> for MdParseEnum {
             }
             Rule::sentence | Rule::t_sentence | Rule::footnote_sentence => Self::Sentence,
             Rule::table_cell => Self::TableCell,
-            Rule::table_seperator => Self::TableSeperator,
+            Rule::table_separator => Self::TableSeparator,
             Rule::u_list => Self::UnorderedList,
             Rule::o_list => Self::OrderedList,
             Rule::h1 | Rule::h2 | Rule::h3 | Rule::h4 | Rule::h5 | Rule::h6 | Rule::heading => {
@@ -618,8 +618,8 @@ impl From<Rule> for MdParseEnum {
             Rule::table => Self::Table,
             Rule::quote => Self::Quote,
             Rule::task => Self::Task,
-            Rule::block_sep => Self::BlockSeperator,
-            Rule::horizontal_sep => Self::HorizontalSeperator,
+            Rule::block_sep => Self::BlockSeparator,
+            Rule::horizontal_sep => Self::HorizontalSeparator,
             Rule::link_data | Rule::wiki_link_data => Self::LinkData,
             Rule::warning => Self::Warning,
             Rule::note => Self::Note,


### PR DESCRIPTION
- `md.pest`: `table_seperator` → `table_separator`
- `parser.rs`: `TableSeperator`, `BlockSeperator`, `HorizontalSeperator`
- `textcomponent.rs`: `HorizontalSeperator`
- `word.rs`: `BlockSeperator`, `HorizontalSeperator`, `TableSeperator`
- `markdown_renderer.rs`: `render_horizontal_seperator`

No behavior changes, pure rename.