### PR TITLE
Fix Elixir highlighting using wrong query language

### DIFF
--- a/src/highlight/elixir.rs
+++ b/src/highlight/elixir.rs
@@ -9,7 +9,7 @@ pub fn highlight_elixir(lines: &[u8]) -> Result<Vec<HighlightEvent>, String> {
     let mut elixir_config = HighlightConfiguration::new(
         language.into(),
         "elixir",
-        tree_sitter_cpp::HIGHLIGHT_QUERY,
+        tree_sitter_elixir::HIGHLIGHTS_QUERY,
         "",
         "",
     )


### PR DESCRIPTION
`elixir.rs` was using `tree_sitter_cpp::HIGHLIGHT_QUERY` instead of `tree_sitter_elixir::HIGHLIGHTS_QUERY`. This caused C++ highlight queries to be applied to Elixir syntax trees, producing incorrect highlighting. 

Verified by viewing a markdown file containing an Elixir code block. Highlighting looks correct.