### PR TITLE
Add syntax highlighting for Diff, Nushell, Protobuf, and TOML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,6 +1388,7 @@ dependencies = [
  "tree-sitter-c",
  "tree-sitter-cpp",
  "tree-sitter-css",
+ "tree-sitter-diff",
  "tree-sitter-elixir",
  "tree-sitter-go",
  "tree-sitter-highlight",
@@ -1397,11 +1398,14 @@ dependencies = [
  "tree-sitter-json",
  "tree-sitter-lua",
  "tree-sitter-luau-fork",
+ "tree-sitter-nu",
  "tree-sitter-ocaml",
  "tree-sitter-php",
+ "tree-sitter-proto",
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-scala",
+ "tree-sitter-toml-ng",
  "tree-sitter-typescript",
  "tree-sitter-yaml",
  "unicode-width",
@@ -2919,6 +2923,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-diff"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfe1e5ca280a65dfe5ba4205c1bcc84edf486464fed315db53dee6da9a335889"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-elixir"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3017,6 +3031,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-nu"
+version = "0.0.1"
+source = "git+https://github.com/nushell/tree-sitter-nu#bb3f533e5792260291945e1f329e1f0a779def6e"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-ocaml"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3031,6 +3054,15 @@ name = "tree-sitter-php"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c17c3ab69052c5eeaa7ff5cd972dd1bc25d1b97ee779fec391ad3b5df5592"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-proto"
+version = "0.4.0"
+source = "git+https://github.com/coder3101/tree-sitter-proto#3ef027b83540c1c161bea64257654ab3d198ad54"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -3061,6 +3093,16 @@ name = "tree-sitter-scala"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7516aeb3d1f40ede8e3045b163e86993b3434514dd06c34c0b75e782d9a0b251"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-toml-ng"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9adc2c898ae49730e857d75be403da3f92bb81d8e37a2f918a08dd10de5ebb1"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tree-sitter = [
   "tree-sitter-c",
   "tree-sitter-cpp",
   "tree-sitter-css",
+  "tree-sitter-diff",
   "tree-sitter-elixir",
   "tree-sitter-go",
   "tree-sitter-html",
@@ -30,11 +31,14 @@ tree-sitter = [
   "tree-sitter-json",
   "tree-sitter-lua",
   "tree-sitter-luau-fork",
+  "tree-sitter-nu",
   "tree-sitter-ocaml",
   "tree-sitter-php",
+  "tree-sitter-proto",
   "tree-sitter-python",
   "tree-sitter-rust",
   "tree-sitter-scala",
+  "tree-sitter-toml-ng",
   "tree-sitter-typescript",
   "tree-sitter-yaml"
 ]
@@ -77,6 +81,10 @@ tree-sitter-rust = { version = "0.24.0", optional = true }
 tree-sitter-scala = { version = "0.24.0", optional = true }
 tree-sitter-typescript = { version = "0.23.2", optional = true }
 tree-sitter-yaml = { version = "0.7.2", optional = true }
+tree-sitter-diff = { version = "0.1.0", optional = true }
+tree-sitter-nu = { git = "https://github.com/nushell/tree-sitter-nu", optional = true }
+tree-sitter-proto = { git = "https://github.com/coder3101/tree-sitter-proto", optional = true }
+tree-sitter-toml-ng = { version = "0.7.0", optional = true }
 
 [build-dependencies]
 cc="1"

--- a/src/highlight/diff.rs
+++ b/src/highlight/diff.rs
@@ -1,0 +1,30 @@
+use tree_sitter_highlight::{HighlightConfiguration, HighlightEvent, Highlighter};
+
+use crate::highlight::HIGHLIGHT_NAMES;
+
+pub fn highlight_diff(lines: &[u8]) -> Result<Vec<HighlightEvent>, String> {
+    let mut highlighter = Highlighter::new();
+    let language = tree_sitter_diff::LANGUAGE;
+
+    let mut diff_config = HighlightConfiguration::new(
+        language.into(),
+        "diff",
+        tree_sitter_diff::HIGHLIGHTS_QUERY,
+        "",
+        "",
+    )
+    .unwrap();
+
+    diff_config.configure(&HIGHLIGHT_NAMES);
+
+    let highlights: Result<Vec<HighlightEvent>, String> =
+        if let Ok(lines) = highlighter.highlight(&diff_config, lines, None, |_| None) {
+            lines
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| e.to_string())
+        } else {
+            Err("Failed to highlight".to_string())
+        };
+
+    highlights
+}

--- a/src/highlight/mod.rs
+++ b/src/highlight/mod.rs
@@ -24,18 +24,26 @@ mod lua;
 mod ocaml;
 #[cfg(feature = "tree-sitter-php")]
 mod php;
+#[cfg(feature = "tree-sitter-proto")]
+mod protobuf;
 #[cfg(feature = "tree-sitter-python")]
 mod python;
 #[cfg(feature = "tree-sitter-rust")]
 mod rust;
 #[cfg(feature = "tree-sitter-scala")]
 mod scala;
+#[cfg(feature = "tree-sitter-toml-ng")]
+mod toml;
 #[cfg(feature = "tree-sitter-typescript")]
 mod tsx;
 #[cfg(feature = "tree-sitter-typescript")]
 mod typescript;
 #[cfg(feature = "tree-sitter-yaml")]
 mod yaml;
+#[cfg(feature = "tree-sitter-diff")]
+mod diff;
+#[cfg(feature = "tree-sitter-nu")]
+mod nu;
 
 use tree_sitter_highlight::HighlightEvent;
 
@@ -134,6 +142,11 @@ pub fn highlight_code(language: &str, lines: &[u8]) -> HighlightInfo {
         #[cfg(feature = "tree-sitter-php")]
         "php" => HighlightInfo::Highlighted(php::highlight_php(lines).unwrap()),
 
+        #[cfg(feature = "tree-sitter-proto")]
+        "proto" | "protobuf" => {
+            HighlightInfo::Highlighted(protobuf::highlight_protobuf(lines).unwrap())
+        }
+
         #[cfg(feature = "tree-sitter-python")]
         "python" => HighlightInfo::Highlighted(python::highlight_python(lines).unwrap()),
 
@@ -142,6 +155,9 @@ pub fn highlight_code(language: &str, lines: &[u8]) -> HighlightInfo {
 
         #[cfg(feature = "tree-sitter-scala")]
         "scala" => HighlightInfo::Highlighted(scala::highlight_scala(lines).unwrap()),
+
+        #[cfg(feature = "tree-sitter-toml-ng")]
+        "toml" => HighlightInfo::Highlighted(toml::highlight_toml(lines).unwrap()),
 
         #[cfg(feature = "tree-sitter-typescript")]
         "tsx" => HighlightInfo::Highlighted(tsx::highlight_tsx(lines).unwrap()),
@@ -153,6 +169,12 @@ pub fn highlight_code(language: &str, lines: &[u8]) -> HighlightInfo {
 
         #[cfg(feature = "tree-sitter-yaml")]
         "yaml" | "yml" => HighlightInfo::Highlighted(yaml::highlight_yaml(lines).unwrap()),
+
+        #[cfg(feature = "tree-sitter-diff")]
+        "diff" | "patch" => HighlightInfo::Highlighted(diff::highlight_diff(lines).unwrap()),
+
+        #[cfg(feature = "tree-sitter-nu")]
+        "nu" | "nushell" => HighlightInfo::Highlighted(nu::highlight_nu(lines).unwrap()),
 
         _ => HighlightInfo::Unhighlighted,
     }

--- a/src/highlight/nu.rs
+++ b/src/highlight/nu.rs
@@ -1,0 +1,451 @@
+use tree_sitter_highlight::{HighlightConfiguration, HighlightEvent, Highlighter};
+
+use crate::highlight::HIGHLIGHT_NAMES;
+
+// Embedded from https://github.com/nushell/tree-sitter-nu/blob/main/queries/nu/highlights.scm
+// MIT License - Copyright (c) nushell contributors
+const HIGHLIGHTS_QUERY: &str = r#"
+; ---
+; keywords
+[
+  "let"
+  "mut"
+  "const"
+] @keyword
+
+[
+  "if"
+  "else"
+  "match"
+] @keyword.conditional
+
+[
+  "loop"
+  "while"
+] @keyword.repeat
+
+"def" @keyword.function
+
+[
+  "try"
+  "catch"
+  "error"
+] @keyword.exception
+
+[
+  "module"
+  "use"
+] @keyword.import
+
+[
+  "alias"
+  "export-env"
+  "export"
+  "extern"
+] @keyword.modifier
+
+(decl_use
+  "use" @keyword)
+
+(ctrl_for
+  "for" @keyword
+  "in" @keyword)
+
+; ---
+; literals
+(val_number) @number
+
+(val_duration
+  unit: _ @variable.parameter)
+
+(val_filesize
+  unit: _ @variable.parameter)
+
+(val_binary
+  [
+    "0b"
+    "0o"
+    "0x"
+  ] @number
+  "[" @punctuation.bracket
+  digit: [
+    "," @punctuation.delimiter
+    (hex_digit) @number
+  ]
+  "]" @punctuation.bracket) @number
+
+(val_bool) @constant.builtin
+
+(val_nothing) @constant.builtin
+
+(val_string) @string
+
+arg_str: (val_string) @variable.parameter
+
+file_path: (val_string) @variable.parameter
+
+(val_date) @number
+
+(inter_escape_sequence) @constant.character.escape
+
+(escape_sequence) @constant.character.escape
+
+(val_interpolated
+  [
+    "$\""
+    "$\'"
+    "\""
+    "\'"
+  ] @string)
+
+(unescaped_interpolated_content) @string
+
+(escaped_interpolated_content) @string
+
+(expr_interpolated
+  [
+    "("
+    ")"
+  ] @variable.parameter)
+
+(raw_string_begin) @punctuation.special
+
+(raw_string_end) @punctuation.special
+
+; ---
+; operators
+(expr_binary
+  opr: _ @operator)
+
+(where_predicate
+  opr: _ @operator)
+
+(assignment
+  [
+    "="
+    "+="
+    "-="
+    "*="
+    "/="
+    "++="
+  ] @operator)
+
+(expr_unary
+  [
+    "not"
+    "-"
+  ] @operator)
+
+(val_range
+  [
+    ".."
+    "..="
+    "..<"
+  ] @operator)
+
+[
+  "=>"
+  "="
+  "|"
+] @operator
+
+[
+  "o>"
+  "out>"
+  "e>"
+  "err>"
+  "e+o>"
+  "err+out>"
+  "o+e>"
+  "out+err>"
+  "o>>"
+  "out>>"
+  "e>>"
+  "err>>"
+  "e+o>>"
+  "err+out>>"
+  "o+e>>"
+  "out+err>>"
+  "e>|"
+  "err>|"
+  "e+o>|"
+  "err+out>|"
+  "o+e>|"
+  "out+err>|"
+] @operator
+
+; ---
+; punctuation
+[
+  ","
+  ";"
+] @punctuation.special
+
+(param_long_flag
+  "--" @punctuation.delimiter)
+
+(long_flag
+  "--" @punctuation.delimiter)
+
+(short_flag
+  "-" @punctuation.delimiter)
+
+(long_flag
+  "=" @punctuation.special)
+
+(short_flag
+  "=" @punctuation.special)
+
+(param_short_flag
+  "-" @punctuation.delimiter)
+
+(param_rest
+  "..." @punctuation.delimiter)
+
+(param_type
+  ":" @punctuation.special)
+
+(param_value
+  "=" @punctuation.special)
+
+(param_completer
+  "@" @punctuation.special)
+
+(attribute
+  "@" @punctuation.special)
+
+(param_opt
+  "?" @punctuation.special)
+
+(returns
+  "->" @punctuation.special)
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
+  "...["
+  "...("
+  "...{"
+] @punctuation.bracket
+
+key: (identifier) @property
+
+; ---
+; identifiers
+(param_rest
+  name: (_) @variable.parameter)
+
+(param_opt
+  name: (_) @variable.parameter)
+
+(parameter
+  param_name: (_) @variable.parameter)
+
+(param_completer
+  (cmd_identifier) @string)
+
+(param_long_flag
+  (long_flag_identifier) @attribute)
+
+(param_short_flag
+  (param_short_flag_identifier) @attribute)
+
+(attribute
+  (attribute_identifier) @attribute)
+
+(short_flag
+  (short_flag_identifier) @attribute)
+
+(long_flag_identifier) @attribute
+
+(scope_pattern
+  (wild_card) @function)
+
+(cmd_identifier) @function
+
+; generated with Nu 0.107.0
+; help commands
+; | where $it.command_type == built-in and $it.category != core
+; | each {$'"($in.name | split row " " | $in.0)"'}
+; | uniq
+; | str join ' '
+(command
+  head: (cmd_identifier) @function.builtin
+  (#any-of? @function.builtin
+    "all" "ansi" "any" "append" "ast" "bits" "bytes" "cal" "cd" "char" "chunk-by" "chunks" "clear"
+    "collect" "columns" "compact" "complete" "config" "cp" "date" "debug" "decode" "default"
+    "detect" "drop" "du" "each" "encode" "enumerate" "every" "exec" "exit" "explain" "explore"
+    "fill" "filter" "find" "first" "flatten" "format" "from" "generate" "get" "glob" "grid"
+    "group-by" "hash" "headers" "histogram" "history" "http" "input" "insert" "inspect" "interleave"
+    "into" "is-empty" "is-not-empty" "is-terminal" "items" "job" "join" "keybindings" "kill" "last"
+    "length" "let-env" "lines" "load-env" "ls" "math" "merge" "metadata" "mkdir" "mktemp" "move"
+    "mv" "nu-check" "nu-highlight" "open" "panic" "par-each" "parse" "path" "plugin" "port"
+    "prepend" "print" "ps" "query" "random" "reduce" "reject" "rename" "reverse" "rm" "roll"
+    "rotate" "run-external" "save" "schema" "select" "seq" "shuffle" "skip" "sleep" "slice" "sort"
+    "sort-by" "split" "start" "stor" "str" "sys" "table" "take" "tee" "term" "timeit" "to" "touch"
+    "transpose" "tutor" "ulimit" "uname" "uniq" "uniq-by" "update" "upsert" "url" "values" "version"
+    "view" "watch" "which" "whoami" "window" "with-env" "wrap" "zip"))
+
+(command
+  head: (cmd_identifier) @keyword.repeat
+  (#any-of? @keyword.repeat "break" "continue" "return"))
+
+(command
+  head: (cmd_identifier) @keyword
+  (#any-of? @keyword "do" "source" "source-env" "hide" "hide-env"))
+
+(command
+  head: (cmd_identifier) @keyword
+  .
+  arg_str: (val_string) @keyword.import
+  (#any-of? @keyword "overlay" "error"))
+
+(command
+  head: (cmd_identifier) @cmd
+  arg_str: (val_string) @keyword
+  (#eq? @cmd "overlay")
+  (#eq? @keyword "as"))
+
+(command
+  "^" @punctuation.delimiter
+  head: (_) @function)
+
+"where" @function.builtin
+
+(where_predicate
+  [
+    "?"
+    "!"
+  ] @punctuation.delimiter)
+
+(path
+  [
+    "."
+    "?"
+    "!"
+  ]* @punctuation.delimiter) @variable.parameter
+
+(stmt_let
+  (identifier) @variable)
+
+(val_variable
+  "$"? @punctuation.special
+  "...$"? @punctuation.special
+  [
+    (identifier) @variable
+    "in" @special
+    "nu" @namespace
+    "env" @constant
+  ]) @none
+
+(val_cellpath
+  "$" @punctuation.special)
+
+(record_entry
+  ":" @punctuation.special)
+
+; ---
+; types
+(flat_type) @type
+
+(list_type
+  "list" @type.enum
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
+
+(collection_type
+  [
+    "record"
+    "table"
+  ] @type.enum)
+
+(collection_type
+  key: (_) @variable.parameter)
+
+(collection_type
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
+
+(collection_type
+  ":" @punctuation.special)
+
+(composite_type
+  "oneof" @type.enum
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
+
+(shebang) @keyword.directive
+
+(comment) @comment
+
+((comment)+ @comment.documentation @spell
+  .
+  (decl_def))
+
+(parameter
+  (comment) @comment.documentation @spell)
+
+(command
+  head: ((cmd_identifier) @_cmd
+    (#match? @_cmd "^\\s*(find|parse|split|str)$"))
+  flag: (_
+    name: (_) @_flag
+    (#any-of? @_flag "r" "regex"))
+  .
+  arg: (_
+    (string_content) @string.regexp))
+
+(_
+  opr: [
+    "=~"
+    "!~"
+    "like"
+    "not-like"
+  ]
+  rhs: (_
+    (string_content) @string.regexp))
+
+(command
+  head: ((_) @_cmd
+    (#any-of? @_cmd "nu" "$nu.current-exe"))
+  flag: (_
+    name: (_) @_flag
+    (#any-of? @_flag "c" "e" "commands" "execute"))
+  .
+  arg: (_
+    (string_content) @string.code))
+"#;
+
+pub fn highlight_nu(lines: &[u8]) -> Result<Vec<HighlightEvent>, String> {
+    let mut highlighter = Highlighter::new();
+    let language = tree_sitter_nu::LANGUAGE;
+
+    let mut nu_config = HighlightConfiguration::new(
+        language.into(),
+        "nu",
+        HIGHLIGHTS_QUERY,
+        "",
+        "",
+    )
+    .unwrap();
+
+    nu_config.configure(&HIGHLIGHT_NAMES);
+
+    if let Ok(lines) = highlighter.highlight(&nu_config, lines, None, |_| None) {
+        lines
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| e.to_string())
+    } else {
+        Err("Failed to highlight".to_string())
+    }
+}

--- a/src/highlight/protobuf.rs
+++ b/src/highlight/protobuf.rs
@@ -1,0 +1,80 @@
+use tree_sitter_highlight::{HighlightConfiguration, HighlightEvent, Highlighter};
+
+use crate::highlight::HIGHLIGHT_NAMES;
+
+// Embedded from https://github.com/coder3101/tree-sitter-proto/blob/main/queries/highlights.scm
+// MIT License - Copyright (c) 2024-2025 Mohammad Ashar Khan
+const HIGHLIGHTS_QUERY: &str = r#"
+[
+  "syntax"
+  "edition"
+  "package"
+  "option"
+  "import"
+  "service"
+  "rpc"
+  "returns"
+  "message"
+  "enum"
+  "oneof"
+  "repeated"
+  "reserved"
+  "to"
+] @keyword
+
+[
+  (key_type)
+  (type)
+  (message_name)
+  (enum_name)
+  (service_name)
+  (rpc_name)
+]@type
+
+(string) @string
+
+[
+  (int_lit)
+  (float_lit)
+] @constant
+
+[
+  (true)
+  (false)
+] @constant
+
+(comment) @property
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+]  @punctuation.bracket
+"#;
+
+pub fn highlight_protobuf(lines: &[u8]) -> Result<Vec<HighlightEvent>, String> {
+    let mut highlighter = Highlighter::new();
+    let language = tree_sitter_proto::LANGUAGE;
+
+    let mut proto_config = HighlightConfiguration::new(
+        language.into(),
+        "protobuf",
+        HIGHLIGHTS_QUERY,
+        "",
+        "",
+    )
+    .unwrap();
+
+    proto_config.configure(&HIGHLIGHT_NAMES);
+
+    if let Ok(lines) = highlighter.highlight(&proto_config, lines, None, |_| None) {
+        lines
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| e.to_string())
+    } else {
+        Err("Failed to highlight".to_string())
+    }
+}

--- a/src/highlight/toml.rs
+++ b/src/highlight/toml.rs
@@ -1,0 +1,83 @@
+use tree_sitter_highlight::{HighlightConfiguration, HighlightEvent, Highlighter};
+
+use crate::highlight::HIGHLIGHT_NAMES;
+
+// Embedded from https://github.com/tree-sitter-grammars/tree-sitter-toml/blob/master/queries/highlights.scm
+// MIT License - Copyright (c) tree-sitter-grammars contributors
+// Modified to map @boolean/@comment/@number to HIGHLIGHT_NAMES equivalents
+const HIGHLIGHTS_QUERY: &str = r#"
+; Properties
+
+(bare_key) @type
+
+(quoted_key) @string
+
+(pair
+  (bare_key)) @property
+
+(pair
+  (dotted_key
+    (bare_key) @property))
+
+; Literals
+
+(boolean) @constant
+
+(comment) @property
+
+(string) @string
+
+[
+  (integer)
+  (float)
+] @constant
+
+[
+  (offset_date_time)
+  (local_date_time)
+  (local_date)
+  (local_time)
+] @string.special
+
+; Punctuation
+
+[
+  "."
+  ","
+] @punctuation.delimiter
+
+"=" @operator
+
+[
+  "["
+  "]"
+  "[["
+  "]]"
+  "{"
+  "}"
+] @punctuation.bracket
+"#;
+
+pub fn highlight_toml(lines: &[u8]) -> Result<Vec<HighlightEvent>, String> {
+    let mut highlighter = Highlighter::new();
+    let language = tree_sitter_toml_ng::LANGUAGE;
+
+    let mut config = HighlightConfiguration::new(
+        language.into(),
+        "toml",
+        HIGHLIGHTS_QUERY,
+        "",
+        "",
+    )
+    .unwrap();
+
+    config.configure(&HIGHLIGHT_NAMES);
+
+    if let Ok(lines) = highlighter.highlight(&config, lines, None, |_| None) {
+        lines
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| e.to_string())
+    } else {
+        Err("Failed to highlight".to_string())
+    }
+}

--- a/test-files/nushell-highlight.md
+++ b/test-files/nushell-highlight.md
@@ -1,0 +1,117 @@
+# Nushell Syntax Highlighting
+
+Test file for Nushell tree-sitter highlighting.
+
+## Variables and strings
+
+```nu
+let name = "world"
+mut counter = 0
+const MAX = 100
+
+print $"Hello, ($name)!"
+print $'literal: ($counter)'
+```
+
+## Control flow
+
+```nu
+if $counter < $MAX {
+    $counter += 1
+} else {
+    print "done"
+}
+
+for item in [1 2 3] {
+    print $item
+}
+
+loop {
+    if $counter >= 10 { break }
+    $counter += 1
+}
+
+match $name {
+    "world" => { print "hi" }
+    _ => { print "who?" }
+}
+```
+
+## Functions and types
+
+```nu
+def greet [name: string, --loud(-l)] -> string {
+    if $loud {
+        $name | str upcase
+    } else {
+        $name
+    }
+}
+
+def sum-all [...nums: int] -> int {
+    $nums | math sum
+}
+```
+
+## Pipelines and builtins
+
+```nu
+ls | where size > 1kb | sort-by modified | first 5
+
+open data.csv | select name age | where age > 30
+
+ps | where cpu > 10 | each { |row| $row.name }
+
+seq 1 100 | par-each { |n| $n * $n } | math sum
+
+http get https://example.com/api | from json | get data
+```
+
+## Records and tables
+
+```nu
+let person = { name: "Alice", age: 30 }
+let scores = [[name, score]; ["Alice", 95], ["Bob", 87]]
+
+$person | get name
+$scores | sort-by score | reverse
+```
+
+## Error handling
+
+```nu
+try {
+    open missing.txt
+} catch {
+    print "file not found"
+}
+```
+
+## Operators and ranges
+
+```nu
+let x = 2 + 3 * 4
+let flag = not false
+let items = 1..10
+let half = 0..<5
+let slice = 0..=3
+```
+
+## Redirects and externals
+
+```nu
+^cargo build o+e>| save build.log
+ls | save files.txt
+```
+
+## Modules
+
+```nu
+module utils {
+    export def double [n: int] -> int {
+        $n * 2
+    }
+}
+
+use utils double
+```

--- a/test-files/toml-highlight.md
+++ b/test-files/toml-highlight.md
@@ -1,0 +1,65 @@
+# TOML Syntax Highlighting
+
+Test file for TOML tree-sitter highlighting regression testing.
+
+```toml
+# Comment - should be blue
+[package]
+name = "my-app"
+version = "0.1.0"
+edition = "2024"
+authors = ["Alice <alice@example.com>", "Bob"]
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1.0", optional = true }
+
+[profile.release]
+lto = true
+opt-level = 3
+debug = false
+
+# Array of tables
+[[bin]]
+name = "app"
+path = "src/main.rs"
+
+[[test]]
+name = "integration"
+path = "tests/integration.rs"
+
+[database]
+server = "192.168.1.1"
+ports = [8000, 8001, 8002]
+enabled = true
+connection_max = 5000
+pi = 3.14159
+negative = -42
+hex = 0xDEADBEEF
+float_special = inf
+
+[dates]
+created = 2024-01-15T10:30:00Z
+local_date = 2024-01-15
+local_time = 10:30:00
+offset = 2024-01-15T10:30:00+09:00
+
+[dotted.keys.example]
+value = "nested via dots"
+
+[inline]
+point = { x = 1, y = 2 }
+colors = ["red", "green", "blue"]
+```
+
+Expected highlighting:
+- Comments: blue
+- Section headers `[package]`: cyan (type)
+- Keys: blue (property)
+- Strings: magenta
+- Booleans (true/false): yellow (constant)
+- Numbers (integers, floats): yellow (constant)
+- Dates/times: magenta (string.special)
+- Brackets `[]`, `{}`: blue
+- Equals `=`: red (operator)
+- Commas, dots: blue (delimiter)


### PR DESCRIPTION
## Summary

Adds tree-sitter-based syntax highlighting for four new languages:

- **Diff/Patch** — via `tree-sitter-diff`
- **Nushell** — via `tree-sitter-nu`
- **Protobuf** — via `tree-sitter-proto`
- **TOML** — via `tree-sitter-toml-ng`

Each language is gated behind an optional Cargo feature flag, following the existing pattern for other highlight modules. Test markdown files are included for Nushell and TOML.

## Details

- New modules: `src/highlight/diff.rs`, `nu.rs`, `protobuf.rs`, `toml.rs`
- Wired into `src/highlight/mod.rs` with `#[cfg(feature = ...)]` gates
- Fenced code blocks are matched by common aliases (e.g., `diff`/`patch`, `nu`/`nushell`, `proto`/`protobuf`, `toml`)

Happy to break this into four separate PRs (one per language) if that makes review easier.

## Test plan

- [ ] `cargo build --all-features` compiles cleanly
- [ ] Render `test-files/nushell-highlight.md` and `test-files/toml-highlight.md` to verify highlighting
- [ ] Render a markdown file containing `diff` and `protobuf` fenced code blocks