### PR TITLE
Add syntax highlighting for diff/patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,6 +1388,7 @@ dependencies = [
  "tree-sitter-c",
  "tree-sitter-cpp",
  "tree-sitter-css",
+ "tree-sitter-diff",
  "tree-sitter-elixir",
  "tree-sitter-go",
  "tree-sitter-highlight",
@@ -2913,6 +2914,16 @@ name = "tree-sitter-css"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5cbc5e18f29a2c6d6435891f42569525cf95435a3e01c2f1947abcde178686f"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-diff"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfe1e5ca280a65dfe5ba4205c1bcc84edf486464fed315db53dee6da9a335889"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tree-sitter = [
   "tree-sitter-c",
   "tree-sitter-cpp",
   "tree-sitter-css",
+  "tree-sitter-diff",
   "tree-sitter-elixir",
   "tree-sitter-go",
   "tree-sitter-html",
@@ -36,7 +37,7 @@ tree-sitter = [
   "tree-sitter-rust",
   "tree-sitter-scala",
   "tree-sitter-typescript",
-  "tree-sitter-yaml"
+  "tree-sitter-yaml",
 ]
 network = ["ureq"]
 
@@ -77,6 +78,7 @@ tree-sitter-rust = { version = "0.24.0", optional = true }
 tree-sitter-scala = { version = "0.24.0", optional = true }
 tree-sitter-typescript = { version = "0.23.2", optional = true }
 tree-sitter-yaml = { version = "0.7.2", optional = true }
+tree-sitter-diff = { version = "0.1.0", optional = true }
 
 [build-dependencies]
 cc="1"

--- a/src/highlight/diff.rs
+++ b/src/highlight/diff.rs
@@ -1,0 +1,30 @@
+use tree_sitter_highlight::{HighlightConfiguration, HighlightEvent, Highlighter};
+
+use crate::highlight::HIGHLIGHT_NAMES;
+
+pub fn highlight_diff(lines: &[u8]) -> Result<Vec<HighlightEvent>, String> {
+    let mut highlighter = Highlighter::new();
+    let language = tree_sitter_diff::LANGUAGE;
+
+    let mut diff_config = HighlightConfiguration::new(
+        language.into(),
+        "diff",
+        tree_sitter_diff::HIGHLIGHTS_QUERY,
+        "",
+        "",
+    )
+    .unwrap();
+
+    diff_config.configure(&HIGHLIGHT_NAMES);
+
+    let highlights: Result<Vec<HighlightEvent>, String> =
+        if let Ok(lines) = highlighter.highlight(&diff_config, lines, None, |_| None) {
+            lines
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| e.to_string())
+        } else {
+            Err("Failed to highlight".to_string())
+        };
+
+    highlights
+}

--- a/src/highlight/mod.rs
+++ b/src/highlight/mod.rs
@@ -36,6 +36,8 @@ mod tsx;
 mod typescript;
 #[cfg(feature = "tree-sitter-yaml")]
 mod yaml;
+#[cfg(feature = "tree-sitter-diff")]
+mod diff;
 
 use tree_sitter_highlight::HighlightEvent;
 
@@ -153,6 +155,9 @@ pub fn highlight_code(language: &str, lines: &[u8]) -> HighlightInfo {
 
         #[cfg(feature = "tree-sitter-yaml")]
         "yaml" | "yml" => HighlightInfo::Highlighted(yaml::highlight_yaml(lines).unwrap()),
+
+        #[cfg(feature = "tree-sitter-diff")]
+        "diff" | "patch" => HighlightInfo::Highlighted(diff::highlight_diff(lines).unwrap()),
 
         _ => HighlightInfo::Unhighlighted,
     }


### PR DESCRIPTION
Adds tree-sitter-based syntax highlighting for diff/patch fenced code blocks.

- `tree-sitter-diff` from crates.io (v0.1.0), gated behind an optional feature flag
- Uses `tree_sitter_diff::HIGHLIGHTS_QUERY` directly from the crate
- Follows the same pattern as the existing highlight modules