### PR TITLE
Found bug from converted word doc - created a fix, and added a test-case

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -508,7 +508,20 @@ fn get_leaf_nodes(node: ParseNode) -> Vec<ParseNode> {
     }
 
     if node.children().is_empty() {
-        leaf_nodes.push(node);
+        // Formatting containers (italic/bold/code/strikethrough) with no named
+        // children arise when the grammar matches only silent content — e.g.
+        // bare newlines between asterisks in CRLF documents.  Nothing to
+        // render; skip so WordType::from is never called on a container type.
+        if !matches!(
+            node.kind(),
+            MdParseEnum::ItalicStr
+                | MdParseEnum::BoldStr
+                | MdParseEnum::BoldItalicStr
+                | MdParseEnum::StrikethroughStr
+                | MdParseEnum::CodeStr
+        ) {
+            leaf_nodes.push(node);
+        }
     } else {
         for child in node.children_owned() {
             leaf_nodes.append(&mut get_leaf_nodes(child));
@@ -772,6 +785,17 @@ mod tests {
             .map(|c| c.kind())
             .collect()
     }
+
+    #[test]
+    fn italic_with_trailing_space_followed_by_italic_crlf() {
+        // italic_var_2 can match " *\r\n\r\n*" (space + asterisk + blank line +
+        // asterisk) with only silent NEWLINE iterations in the body, producing an
+        // ItalicStr node with no named children.  That must not panic.
+        let md = "*Section A*\r\n\r\n*Item with trailing space *\r\n\r\n*Section B*\r\n";
+        let kinds = component_kinds(md);
+        assert!(!kinds.is_empty());
+    }
+
 
     fn has_details_summary(kinds: &[TextNode]) -> bool {
         kinds


### PR DESCRIPTION
Fix: parser panic on empty formatting containers in CRLF documents

 Found a bug triggered by a Word-converted markdown document. When a file uses CRLF line endings, the grammar's italic_var_2 rule can match a sequence like " *\r\n\r\n*" (a trailing space before a blank line followed by a lone
  asterisk) and produce an ItalicStr node with no named children — only silent newline iterations in the body.

 get_leaf_nodes previously pushed every childless node as a leaf, which caused WordType::from to be called on a container type it doesn't handle, resulting in a panic.

 Fix: Skip childless nodes whose kind is a formatting container (ItalicStr, BoldStr, BoldItalicStr, StrikethroughStr, CodeStr). These represent empty/degenerate matches with nothing to render.

 Test added: italic_with_trailing_space_followed_by_italic_crlf reproduces the exact CRLF pattern that triggered the panic and asserts the parser completes without crashing.