### PR TITLE
feat: add --version/-V CLI flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,12 @@ fn main() -> Result<(), Box<dyn Error>> {
         better_panic::Settings::auto().create_panic_handler()(panic_info);
     }));
 
+    let args: Vec<String> = std::env::args().collect();
+    if args.get(1).is_some_and(|a| a == "--version" || a == "-V" || a == "-v") {
+        println!("mdt {}", env!("CARGO_PKG_VERSION"));
+        std::process::exit(0);
+    }
+
     let mut terminal = ratatui::init();
 
     // create app and run it


### PR DESCRIPTION
## Summary

- Adds `--version` and `-V` flags to display the binary version
- Prints `mdt {version}` and exits before TUI initialization
- Uses `CARGO_PKG_VERSION` — no new dependencies

Closes #228

## Changes

| File | Change |
|------|--------|
| `src/main.rs` | Added 6-line version check before `ratatui::init()` |

## Test Plan

- [x] `cargo run -- --version` → outputs `mdt 0.10.1`
- [x] `cargo run -- -V` → outputs `mdt 0.10.1`
- [x] `cargo test` → 35/35 tests pass
- [x] No regression in normal TUI launch